### PR TITLE
Add ability to exclude certain paths from protection

### DIFF
--- a/src/Http/Middleware/SiteProtection.php
+++ b/src/Http/Middleware/SiteProtection.php
@@ -19,6 +19,11 @@ class SiteProtection
     public function handle($request, Closure $next, $guard = null)
     {
         $password = config('site-protection.passwords');
+        $exceptPaths = explode(',', config('site-protection.except_paths'));
+
+        if (in_array($request->path(), $exceptPaths)) {
+            return $next($request);
+        }
 
         if (empty($password)) {
             return $next($request);

--- a/src/config/site-protection.php
+++ b/src/config/site-protection.php
@@ -7,11 +7,12 @@ return [
     | Passwords For Laravel Site Protection
     |--------------------------------------------------------------------------
     |
-    | 
-    | 
+    |
+    |
     |
     */
 
     'passwords' => env('SITE_PROTECTION_PASSWORDS'),
+    'except_paths' => env('SITE_PROTECTION_EXCEPT_PATHS')
 
 ];

--- a/src/config/site-protection.php
+++ b/src/config/site-protection.php
@@ -13,6 +13,6 @@ return [
     */
 
     'passwords' => env('SITE_PROTECTION_PASSWORDS'),
-    'except_paths' => env('SITE_PROTECTION_EXCEPT_PATHS')
+    'except_paths' => env('SITE_PROTECTION_EXCEPT_PATHS') // comma-separated, home as "/", e.g. "/,register,some-url"
 
 ];


### PR DESCRIPTION
1. Laravel envoyer (I guess other services) have a health-check url to check if deployment went through

![2019-09-15_15h49_13](https://user-images.githubusercontent.com/13556916/64921825-79e91a80-d7d0-11e9-8ab0-85946d1739e3.png)

2. When you develop, sometimes services send webhooks so it'd be convenient to exclude those paths from protection.