### PR TITLE
Laravel ^6.0 upgrade

### DIFF
--- a/src/Http/Middleware/SiteProtection.php
+++ b/src/Http/Middleware/SiteProtection.php
@@ -32,7 +32,7 @@ class SiteProtection
         }
 
         try {
-            $usersPassword = decrypt(array_get($_COOKIE, 'site-password-protected'));
+            $usersPassword = decrypt(\Arr::get($_COOKIE, 'site-password-protected'));
             if (in_array($usersPassword, $passwords)) {
                 return $next($request);
             }


### PR DESCRIPTION
As of 6.0 Laravel uses Arr::get() instead of array_get()